### PR TITLE
Migrate database connection layer from DynamoDB to MongoDB

### DIFF
--- a/chalicelib/ddb.py
+++ b/chalicelib/ddb.py
@@ -3,114 +3,98 @@ import logging
 import os
 from datetime import datetime
 
-import boto3
-from boto3.dynamodb.conditions import Key
+from pymongo import MongoClient, DESCENDING, ASCENDING
+from pymongo.errors import DuplicateKeyError
 
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 
 
-def create_connection(table_name):
-    ddb = None
+def create_connection(collection_name):
+    client = None
     if os.getenv('API_ENDPOINT') != 'localhost':
-        ddb = boto3.resource('dynamodb')
+        mongodb_uri = os.getenv('MONGODB_URI', 'mongodb://localhost:27017')
+        client = MongoClient(mongodb_uri)
     else:
-        ddb = boto3.resource('dynamodb', endpoint_url='http://localhost:8000')
+        client = MongoClient('mongodb://localhost:27017')
 
-    ddb_table = ddb.Table(table_name)
-    return ddb_table
+    db = client['chat_db']
+    collection = db[collection_name]
+
+    collection.create_index([('chat_room', ASCENDING), ('time', DESCENDING)], name='chat_room_time_idx')
+    collection.create_index([('name', ASCENDING), ('time', ASCENDING)], unique=True, name='name_time_idx')
+
+    return collection
 
 
 class DdbChat():
-    def putComment(self, table, name, comment, chat_room):
-        logging.info('PutComments params : %s %s %s %s', table, name, comment, chat_room)
+    def putComment(self, collection, name, comment, chat_room):
+        logging.info('PutComments params : %s %s %s %s', collection, name, comment, chat_room)
         now = str(datetime.now().timestamp())
 
-        result = table.put_item(
-            Item={
-                'name': name,
+        document = {
+            'name': name,
+            'time': now,
+            'comment': comment,
+            'chat_room': chat_room
+        }
+
+        try:
+            collection.insert_one(document)
+            result = {
                 'time': now,
-                'comment': comment,
-                'chat_room': chat_room
-            },
-            ReturnValues='ALL_OLD',
-            ReturnConsumedCapacity='TOTAL',
-            ExpressionAttributeNames={'#T': 'time', '#N': 'name'},
-            ConditionExpression='attribute_not_exists(#T) And attribute_not_exists(#N)'
-        )
-        result['time'] = now
-        logging.info('put_item result :' + str(result))
+                'ResponseMetadata': {
+                    'HTTPStatusCode': 200
+                }
+            }
+            logging.info('insert_one result :' + str(result))
+            return result
+        except DuplicateKeyError:
+            logging.error('Duplicate key error: document with name=%s and time=%s already exists', name, now)
+            raise
 
-        return result
+    def getLatestComments(self, collection, chat_room, item_count):
+        logging.info('getLatestComments params : %s %s', collection, chat_room)
 
-    def getLatestComments(self, table, chat_room, item_count):
-        logging.info('getLatestComments params : %s %s', table, chat_room)
+        cursor = collection.find({'chat_room': chat_room}).sort('time', DESCENDING).limit(item_count)
+        items = []
+        for doc in cursor:
+            doc.pop('_id', None)
+            items.append(doc)
 
-        response = table.query(
-            IndexName='chat_room_time_idx',
-            Select='ALL_ATTRIBUTES',
-            KeyConditionExpression=Key('chat_room').eq(chat_room),
-            ScanIndexForward=False,
-            Limit=item_count
-        )
+        response = {
+            'Items': items,
+            'Count': len(items),
+            'ScannedCount': len(items)
+        }
 
         return response
 
-    def getRangeComments(self, table, chat_room, position):
-        logging.info('getRangeComments params : %s %s %s', table, chat_room, str(position))
+    def getRangeComments(self, collection, chat_room, position):
+        logging.info('getRangeComments params : %s %s %s', collection, chat_room, str(position))
 
         result = []
 
-        response = table.query(
-            IndexName='chat_room_time_idx',
-            Select='ALL_ATTRIBUTES',
-            KeyConditionExpression=Key('chat_room').eq(chat_room) & Key('time').gt(position),
-            ScanIndexForward=False
-        )
-        for index, item in enumerate(response['Items']):
-            result.append(item)
+        cursor = collection.find({
+            'chat_room': chat_room,
+            'time': {'$gt': position}
+        }).sort('time', DESCENDING)
 
-        while 'LastEvaluatedKey' in response:
-            print('LastEvaluatedKey Hit!!!')
-            response = table.query(
-                IndexName='chat_room_time_idx',
-                Select='ALL_ATTRIBUTES',
-                KeyConditionExpression=Key('chat_room').eq(chat_room) & Key('time').gt(position),
-                ScanIndexForward=False,
-                ExclusiveStartKey=response['LastEvaluatedKey']
-            )
-
-            for index, item in enumerate(response['Items']):
-                result.append(item)
+        for doc in cursor:
+            doc.pop('_id', None)
+            result.append(doc)
 
         return result
 
-    def getAllComments(self, table, chat_room):
-        logging.info('getAllComments params : %s %s', table, chat_room)
+    def getAllComments(self, collection, chat_room):
+        logging.info('getAllComments params : %s %s', collection, chat_room)
 
         result = []
 
-        response = table.query(
-            IndexName='chat_room_time_idx',
-            Select='ALL_ATTRIBUTES',
-            KeyConditionExpression=Key('chat_room').eq(chat_room),
-            ScanIndexForward=False
-        )
+        cursor = collection.find({'chat_room': chat_room}).sort('time', DESCENDING)
 
-        for index, item in enumerate(response['Items']):
-            result.append(item)
-
-        while 'LastEvaluatedKey' in response:
-            print('LastEvaluatedKey Hit!!!')
-            response = table.query(
-                IndexName='chat_room_time_idx',
-                Select='ALL_ATTRIBUTES',
-                KeyConditionExpression=Key('chat_room').eq(chat_room),
-                ScanIndexForward=False,
-                ExclusiveStartKey=response['LastEvaluatedKey']
-            )
-
-            for index, item in enumerate(response['Items']):
-                result.append(item)
+        for doc in cursor:
+            doc.pop('_id', None)
+            result.append(doc)
 
         return result
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 pytest
-boto3
+pymongo
 chalice
 flake8
-moto
 pytest-chalice
 pytest-env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,21 @@
 # -*- coding: utf-8 -*-
 import os
 
-import boto3
+from pymongo import MongoClient, ASCENDING, DESCENDING
 import pytest
 
 from app import app as chalice_app
 
-DDB_TABLE_NAME = 'chat'  # TODO: Better to acquire from other constant or configured env var
+COLLECTION_NAME = 'chat'
 
 if os.environ['API_ENDPOINT'] == 'localhost':
-    ddb = boto3.resource('dynamodb', endpoint_url='http://localhost:8000')
+    client = MongoClient('mongodb://localhost:27017')
 else:
-    ddb = boto3.resource('dynamodb')
+    mongodb_uri = os.getenv('MONGODB_URI', 'mongodb://localhost:27017')
+    client = MongoClient(mongodb_uri)
 
-table = ddb.Table(DDB_TABLE_NAME)
+db = client['chat_db']
+collection = db[COLLECTION_NAME]
 
 
 @pytest.fixture
@@ -21,80 +23,25 @@ def app():
     return chalice_app
 
 
-def _create_test_ddb_table():
-    return ddb.create_table(
-        TableName=DDB_TABLE_NAME,
-        AttributeDefinitions=[
-            {
-                'AttributeName': 'name',
-                'AttributeType': 'S',
-            },
-            {
-                'AttributeName': 'time',
-                'AttributeType': 'S',
-            },
-            {
-                'AttributeName': 'chat_room',
-                'AttributeType': 'S',
-            },
-        ],
-        KeySchema=[
-            {
-                'AttributeName': 'name',
-                'KeyType': 'HASH',
-            },
-            {
-                'AttributeName': 'time',
-                'KeyType': 'RANGE',
-            },
-        ],
-        GlobalSecondaryIndexes=[{
-            'IndexName': 'chat_room_time_idx',
-            'KeySchema': [
-                {
-                    'AttributeName': 'chat_room',
-                    'KeyType': 'HASH',
-                },
-                {
-                    'AttributeName': 'time',
-                    'KeyType': 'RANGE',
-                },
-            ],
-            'Projection': {
-                'ProjectionType': 'ALL',
-            },
-            'ProvisionedThroughput': {
-                'ReadCapacityUnits': 100,
-                'WriteCapacityUnits': 100
-            }
-        }],
-        ProvisionedThroughput={
-            'ReadCapacityUnits': 100,
-            'WriteCapacityUnits': 100
-        },
-
-    )
+def _create_test_mongodb_collection():
+    collection.create_index([('chat_room', ASCENDING), ('time', DESCENDING)], name='chat_room_time_idx')
+    collection.create_index([('name', ASCENDING), ('time', ASCENDING)], unique=True, name='name_time_idx')
+    return collection
 
 
-def ddb_test_data_put():
-    table.put_item(
-        Item={
-            'name': 'test_name',
-            'time': 'test_time',
-            'comment': 'test_data',
-            'chat_room': 'test_chat'
-        },
-        ReturnValues='ALL_OLD',
-        ReturnConsumedCapacity='TOTAL'
-    )
+def mongodb_test_data_put():
+    collection.insert_one({
+        'name': 'test_name',
+        'time': 'test_time',
+        'comment': 'test_data',
+        'chat_room': 'test_chat'
+    })
 
 
 @pytest.fixture(autouse=True, scope='session')
 def ddb_table():
-    _create_test_ddb_table()
-    table.wait_until_exists()
-    ddb_test_data_put()
+    _create_test_mongodb_collection()
+    mongodb_test_data_put()
 
-    yield table
-    table.delete()
-    table.wait_until_not_exists()
+    yield collection
+    collection.drop()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,7 +2,7 @@
 import json
 from http import HTTPStatus
 
-import boto3
+from pymongo import MongoClient
 
 
 def test_get_all_comments(client):
@@ -36,19 +36,18 @@ def test_put_add_comment(client):
                            headers={'Content-Type': 'application/json'},
                            body=json.dumps({'name': 'oranie', 'comment': 'test done'}))
 
-    ddb = boto3.resource('dynamodb', endpoint_url='http://127.0.0.1:8000')
-    tbl = ddb.Table('chat')
-    get_result = tbl.get_item(
-        Key={
-            'name': 'oranie',
-            'time': str(response.json['time'])
-        }
-    )
+    mongo_client = MongoClient('mongodb://localhost:27017')
+    db = mongo_client['chat_db']
+    collection = db['chat']
+    get_result = collection.find_one({
+        'name': 'oranie',
+        'time': str(response.json['time'])
+    })
 
     print('Get Item : ' + str(get_result))
 
     assert response.status_code == HTTPStatus.OK
     assert response.json['state'] == 'Commment add OK'
     assert 'time' in response.json
-    assert 'oranie' in get_result['Item']['name']
-    assert 'test done' in get_result['Item']['comment']
+    assert 'oranie' in get_result['name']
+    assert 'test done' in get_result['comment']


### PR DESCRIPTION
# Migrate database connection layer from DynamoDB to MongoDB

## Summary
This PR completely migrates the database layer from AWS DynamoDB to MongoDB. All database operations in `chalicelib/ddb.py` have been rewritten to use PyMongo instead of boto3, while maintaining the same API interface for the rest of the application.

**Key changes:**
- Replaced `boto3` with `pymongo` in dependencies
- Rewrote `create_connection()` to establish MongoDB client connections
- Converted all `DdbChat` methods to use MongoDB operations (find, insert_one, sort, etc.)
- Created MongoDB indexes to replicate DynamoDB's GSI functionality
- Updated test fixtures and assertions to work with MongoDB

**Schema mapping:**
- DynamoDB table → MongoDB collection named `chat` in database `chat_db`
- DynamoDB primary key (name, time) → MongoDB unique compound index on (name, time)
- DynamoDB GSI `chat_room_time_idx` → MongoDB compound index on (chat_room, time)

## Review & Testing Checklist for Human

**⚠️ CRITICAL - This PR has NOT been tested end-to-end. The following items MUST be verified:**

- [ ] **MongoDB is running locally** - Tests will fail without MongoDB running on `localhost:27017`
- [ ] **Run the test suite** - Execute `pytest` to verify all tests pass with MongoDB
- [ ] **Test the application locally** - Start the app with `chalice local` and verify chat functionality works (post comments, retrieve latest, retrieve all, retrieve range)
- [ ] **Verify time-based queries work correctly** - The `time` field is stored as a string timestamp. Confirm that MongoDB's string comparison with `$gt` operator correctly retrieves messages in chronological order
- [ ] **Configure production environment** - Set `MONGODB_URI` environment variable for non-localhost deployments (currently defaults to localhost if not set, which will break in production)
- [ ] **Review index creation strategy** - Indexes are created on every `create_connection()` call. This is safe but inefficient - consider moving to a one-time migration script for production

### Notes
- The test fixture is still named `ddb_table` for backward compatibility, even though it now returns a MongoDB collection
- Removed `moto` dependency (DynamoDB mocking library) as it's no longer needed
- The pagination logic using DynamoDB's `LastEvaluatedKey` has been removed - MongoDB cursors handle this automatically, which should be fine for typical chat volumes
- Error handling for duplicate inserts now uses MongoDB's `DuplicateKeyError` instead of DynamoDB's conditional expressions

**Session info:**
- Requested by: Abhay Aggarwal (abhay.aggarwal@cognition.ai)
- Devin session: https://app.devin.ai/sessions/e3c0eb6319344925918898e2d09ec2fb
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/amazon-dynamodb-chat-sample/pull/11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
